### PR TITLE
Fix pip-sync being incomplete

### DIFF
--- a/devtools.ps1
+++ b/devtools.ps1
@@ -31,6 +31,7 @@ function Upgrade-Requirements {
     "conda env update --prune"
 
     # Update the pip dependencies
+    # TODO use --resolver=backtracking once https://github.com/jazzband/pip-tools/pull/1808 is merged
     Invoke-Expression "pip-compile --upgrade -v requirements/prod.in"
     Invoke-Expression "pip-compile --upgrade -v requirements/dev.in"
 }
@@ -38,9 +39,9 @@ function Upgrade-Requirements {
 # Install frozen pip packages and PyTorch
 function Install {
     Activate
-    Invoke-Expression "pip-sync requirements/dev.txt"
+    Invoke-Expression "pip-sync requirements/prod.txt requirements/dev.txt"
     # Force upgrade to CUDA version of PyTorch
-    Invoke-Expression "pip install --upgrade torch --extra-index-url https://download.pytorch.org/whl/cu117"
+    Invoke-Expression "pip install --upgrade torch --extra-index-url https://download.pytorch.org/whl/cu117 --user"
     Invoke-Expression "pip install -e ."
     Invoke-Expression "pre-commit install"
 }

--- a/devtools.sh
+++ b/devtools.sh
@@ -39,7 +39,7 @@ function upgrade_requirements {
 # Install frozen pip packages
 function install {
     activate
-    pip-sync requirements/dev.txt
+    pip-sync requirements/prod.txt requirements/dev.txt
     pip install -e .
     pre-commit install
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -58,7 +58,7 @@ distlib==0.3.6
     # via virtualenv
 docutils==0.19
     # via sphinx
-esbonio==0.16.0
+esbonio==0.16.1
     # via -r requirements/dev.in
 exceptiongroup==1.1.0
     # via cattrs
@@ -93,7 +93,7 @@ jedi==0.18.2
     # via ipython
 jinja2==3.1.2
     # via sphinx
-jupyter-client==8.0.2
+jupyter-client==8.0.3
     # via ipykernel
 jupyter-core==5.2.0
     # via
@@ -113,7 +113,7 @@ matplotlib-inline==0.1.6
     #   ipython
 mccabe==0.7.0
     # via pylint
-mypy==1.0.0
+mypy==1.0.1
     # via -r requirements/dev.in
 mypy-extensions==1.0.0
     # via
@@ -151,7 +151,7 @@ psutil==5.9.4
     #   ipykernel
 pure-eval==0.2.2
     # via stack-data
-pygls==1.0.0
+pygls==1.0.1
     # via esbonio
 pygments==2.14.0
     # via

--- a/requirements/prod.txt
+++ b/requirements/prod.txt
@@ -40,7 +40,7 @@ frozenlist==1.3.3
     #   aiosignal
 fsspec[http]==2023.1.0
     # via datasets
-huggingface-hub==0.12.0
+huggingface-hub==0.12.1
     # via
     #   datasets
     #   transformers


### PR DESCRIPTION
Development note: I misunderstood how the `-c` flag works in `pip-tools` (which is in our dev.in): it's a constraint, not copy, meaning it's not enough to just `pip-sync dev.txt`. I'm opening a PR to fix this, but in the meantime you should be able to manually run the following to correctly install your environment:
```pip-sync requirements/prod.txt requirements/dev.txt```
If on Windows and want CUDA support, you might then need to force upgrade torch with:
```pip install --upgrade torch --extra-index-url https://download.pytorch.org/whl/cu117 --user```